### PR TITLE
Fix yml deprecation

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,8 +1,8 @@
 services:
     insomnia_max_mind_geo_ip_service:
         class: Insomnia\MaxMindGeoIpBundle\Service\GeoIpService
-        arguments: [@insomnia_max_mind_geo_ip]
+        arguments: ['@insomnia_max_mind_geo_ip']
 
     insomnia_max_mind_geo_ip:
         class: MaxMind\Db\Reader
-        arguments: [%insomnia_max_mind_db_path%]
+        arguments: ['%insomnia_max_mind_db_path%']


### PR DESCRIPTION
Not quoting the scalar "@insomnia_max_mind_geo_ip" starting with "@" is deprecated since Symfony 2.8 and will throw a ParseException in 3.0.
